### PR TITLE
Fix the formatting in the examples documentation

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -14,4 +14,4 @@ terraform apply
 ```
 
 Note that this example may create resources which can cost money (AWS Elastic IP, for example).
-Run `terraform destroy`` when you don't need these resources.
+Run `terraform destroy` when you don't need these resources.

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -13,4 +13,4 @@ terraform apply
 ```
 
 Note that this example may create resources which can cost money (AWS Elastic IP, for example).
-Run `terraform destroy`` when you don't need these resources.
+Run `terraform destroy` when you don't need these resources.


### PR DESCRIPTION
**Description**
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix the command Markdown formatting in the `examples` directory.