### PR TITLE
Turn off Checkov in super-linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,4 +39,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_TERRAFORM_TERRASCAN: false
           ERROR_ON_MISSING_EXEC_BIT: true
-          VALIDATE_CHECKOV
+          VALIDATE_CHECKOV: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,3 +39,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_TERRAFORM_TERRASCAN: false
           ERROR_ON_MISSING_EXEC_BIT: true
+          VALIDATE_CHECKOV


### PR DESCRIPTION
Turning off Checkov in super-linter as it leads to false positives. Checkov runs in its own workflow.